### PR TITLE
Refactored to use variables to set the full class names and not hard …

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -1,5 +1,10 @@
 const HomeInventory = JSON.parse(localStorage.getItem("homeInventory"));
 const inventoryEl = document.getElementsByClassName("inventory")[0];
+let propName;
+let propLocation;
+let propType;
+let propDescription;
+
 
 console.log("HomeInventory:", HomeInventory);
 //console.log(HomeInventory.electronics)
@@ -17,17 +22,36 @@ for (var key in HomeInventory) {
     for (var i = 0; i < categoryArray.length; i++) {
         var item = categoryArray[i];
 
-    // hardcoded the __name to avoid another for in loop to access property names
+        // loop through each object in the array and populate a variable for each key property name
+        for (prop in item) {
+            switch (true) {
+                case (prop === "name"):
+                    propName = prop;
+                    break;
+                case (prop === "location"):
+                    propLocation = prop;
+                    break;
+                case (prop === "type"):
+                    propType = prop;
+                    break;
+                case (prop === "description"):
+                    propDescription = prop;
+                    break;
+            }
+        }
+
+    // Sets innerHTML of page with data from each object in database. 
+    // Uses variables that were populated by the for in loop over the object "Item" to set the back half of each class name; name, location, description, type.
         inventoryEl.innerHTML += `
         <section class="${item.type}">
-            <h2 class="${item.type}__name">
+            <h2 class="${item.type}__${propName}">
             ${item.name}
             </h2>
-            <div class="${item.type}__location">
-            Location: ${item.location}
+            <div class="${item.type}__${propLocation}">
+            ${propLocation}: ${item.location}
             </div>
-            <div class="${item.type}__description">
-            ${item.description}
+            <div class="${item.type}__${propDescription}">
+            ${propDescription}: ${item.description}
             </div>
         </section>
         `


### PR DESCRIPTION
Refactored to use variables to set the full class names and not hardcode the __name portion.

1. git fetch --all
1. git checkout tryinganotherNestedForInLoop
1. run http-server and connect to localhost:8080
1. check the html code in Chrome Dev tools and drill into the code for the first section inside the <article class="inventory">. Make sure class names are populated as "electronics__name" "electronics__location" "electronics__description"
1. check the webpage preview and make sure each item has a heading with name, and each line of the text below starts with "location:" and "description"